### PR TITLE
Add -> as alias for :=

### DIFF
--- a/src/gui/control/item_list.cpp
+++ b/src/gui/control/item_list.cpp
@@ -180,10 +180,10 @@ void ItemList::refreshList(bool refresh_current_only) {
   // refresh
   // Note: Freeze/Thaw makes flicker worse
   long item_count = (long)sorted_list.size();
+  SetItemCount(item_count);
   if (item_count == 0) {
     Refresh();
   } else {
-    SetItemCount(item_count);
     // (re)select current item
     findSelectedItemPos();
     focusNone();

--- a/src/script/parser.cpp
+++ b/src/script/parser.cpp
@@ -122,7 +122,7 @@ bool isOper  (wxUniChar c) { return wxStrchr(_("+-*/!.@%^&:=<>;,"),c) != nullptr
 bool isLparen(wxUniChar c) { return c==_('(') || c==_('[') || c==_('{'); }
 bool isRparen(wxUniChar c) { return c==_(')') || c==_(']') || c==_('}'); }
 bool isDigitOrDot(wxUniChar c) { return isDigit(c) || c==_('.'); }
-bool isLongOper(StringView s) { return s==_(":=") || s==_("==") || s==_("!=") || s==_("<=") || s==_(">="); }
+bool isLongOper(StringView s) { return s==_(":=") || s==_("==") || s==_("!=") || s==_("<=") || s==_(">=") || s==_("->"); }
 
 // moveme
 // ----------------------------------------------------------------------------- : Tokenizing
@@ -351,7 +351,7 @@ enum Precedence
 {  PREC_ALL
 ,  PREC_NEWLINE  // newline ;
 ,  PREC_SEQ    // ;
-,  PREC_SET    // :=
+,  PREC_SET    // := ->
 ,  PREC_AND    // and or
 ,  PREC_CMP    // == != < > <= >=
 ,  PREC_ADD    // + -
@@ -736,7 +736,7 @@ ExprType parseOper(TokenIterator& input, Script& script, Precedence minPrec, Ins
       }
       script.addInstruction(I_POP); // discard result of first expression
       type = parseOper(input, script, PREC_SET);
-    } else if (minPrec <= PREC_SET && token==_(":=")) {
+    } else if (minPrec <= PREC_SET && (token==_(":=") || token==_("->"))) {
       // We made a mistake, the part before the := should be a variable name,
       // not an expression. Remove that instruction.
       Instruction& instr = script.getInstructions().back();


### PR DESCRIPTION
Adds the -> token, which behaves exactly like :=. this will let the version of MSE we release with the 3.0.0 template pack be more backwards compatible with the version that adds global variables. (it will handle the variable features poorly rather than crash)

(also adds the empty set crash fix ig cause that was on my master and not yours)