### PR TITLE
Add include localized file token

### DIFF
--- a/doc/file/format.txt
+++ b/doc/file/format.txt
@@ -34,6 +34,13 @@ Where filename must be an absolute or relative [[type:filename]].
 
 That file is included literally into the current one; except for indentation, the included file never escapes from the level the 'include file' line is on.
 
+If the file to be included can vary depending on the locale that is selected, use:
+>>>include localized file: <em>filename</em>
+
+MSE will take the filename and add "_" followed by the name of the currently selected locale at the end of it.
+So for example, if the locale used is the folder "en.mse-locale", the file that will be included is "filename_en"
+You must provide a version of the file for each locale found in the data folder, even if it is simply a copy of the english one.
+
 --Example--
 For example, a [[type:set]] might look like this:
 >game: magic

--- a/src/script/parser.cpp
+++ b/src/script/parser.cpp
@@ -182,6 +182,17 @@ void TokenIterator::readToken() {
   } else if (isSpace(c)) {
     ++pos;
     // ignore
+  } else if (is_substr(pos, end, "include localized file:")) {
+    pos += 23; // "include localized file:"
+    const char* newlines = "\r\n";
+    auto eol = find_first_of(pos, end, newlines, newlines + 2);
+    String include_file = trim(StringView(pos, eol)) + _("_") + settings.locale;
+    // include_file("filename_en")
+    addToken(TOK_NAME, "include_file", pos - 23);
+    addToken(TOK_LPAREN, "(", pos);
+    addToken(TOK_STRING, include_file, pos);
+    addToken(TOK_RPAREN, ")", eol);
+    pos = eol;
   } else if (is_substr(pos, end, "include file:")) {
     pos += 13; // "include file:"
     const char* newlines = "\r\n";

--- a/src/util/io/reader.cpp
+++ b/src/util/io/reader.cpp
@@ -12,6 +12,7 @@
 #include <util/error.hpp>
 #include <util/io/package_manager.hpp>
 #include <boost/logic/tribool.hpp>
+#include <data/settings.hpp>
 #undef small
 using boost::tribool;
 
@@ -355,6 +356,10 @@ template <> void Reader::handle(Vector2D& vec) {
 
 template <> void Reader::handle(LocalFileName& f) {
   f = LocalFileName::fromReadString(this->getValue());
+}
+
+String Reader::addLocale(String filename) {
+  return filename + _("_") + settings.locale;
 }
 
 // ----------------------------------------------------------------------------- : EnumReader

--- a/src/util/io/reader.hpp
+++ b/src/util/io/reader.hpp
@@ -117,6 +117,8 @@ public:
   /// The package being read from
   inline Packaged* getPackage() const { return package; }
   
+  String addLocale(String);
+
 private:
   // --------------------------------------------------- : Data
   /// App version this file was made with
@@ -175,7 +177,8 @@ private:
   /** Maybe the key is "include file" */
   template <typename T>
   void unknownKey(T& v) {
-    if (key == _("include_file")) {
+    if (key == _("include_file") || key == _("include_localized_file")) {
+      value = key == _("include_localized_file") ? addLocale(value) : value;
       auto [stream, include_package] = openFileFromPackage(package, value);
       Reader sub_reader(*stream, include_package, value, ignore_invalid);
       if (sub_reader.file_app_version == 0) {

--- a/tools/website/drupal/mse-drupal-modules/highlight.inc
+++ b/tools/website/drupal/mse-drupal-modules/highlight.inc
@@ -174,6 +174,8 @@ function highlight_script($code) {
 			      . "<span class='hl-num'>" . $matches[4] . "</span>)</span>";
 		} else if (preg_match("@^(if|then|else|for( each)?|in(?= )|do|div|mod|and|or|xor|not|rgb|rgba|from|to|min|max)\b(?!:)@",$code, $matches)) {
 			$ret .= "<span class='hl-kw'>" . $matches[0] . "</span>";
+		} else if (preg_match("@^(include localized file:)(.*)@",$code, $matches)) {
+			$ret .= "<span class='hl-key'>" . $matches[1] . "</span>" . $matches[2];
 		} else if (preg_match("@^(include file:)(.*)@",$code, $matches)) {
 			$ret .= "<span class='hl-key'>" . $matches[1] . "</span>" . $matches[2];
 		} else if (preg_match("@^([0-9][0-9.]*|true|false)@",$code, $matches)) {


### PR DESCRIPTION
If a file to be included can vary depending on the locale that is selected, use:
>>>include localized file: <em>filename</em>

MSE will take the filename and add "_" followed by the name of the currently selected locale at the end of it.
So for example, if the locale used is the folder "en.mse-locale", the file that will be included is "filename_en"