### PR TITLE
font rendering/exporting without installing system-wide

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -64,7 +64,14 @@
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ]
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "VCPKG_MANIFEST_FEATURES",
+          "value": "fonts",
+          "type": "STRING"
+        }
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On windows, the program can be compiled with Visual Studio (recommended) or with
 
 =======
 ````
-.\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
+.\vcpkg install pkgconf wxwidgets[fonts] boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
 ````
 and/or
 ````

--- a/src/data/font.cpp
+++ b/src/data/font.cpp
@@ -37,7 +37,8 @@ bool Font::PreloadResourceFonts(String fontsDirectoryPath, bool recursive) {
   
   // tally fonts
   vector<String> fontFilePaths;
-  if (!TallyResourceFonts(fontsDirectoryPath, fontFilePaths, recursive)) return false;
+  TallyResourceFonts(fontsDirectoryPath, fontFilePaths, recursive);
+  if (fontFilePaths.size() == 0) return false;
 
   // load fonts
   bool preloadHadErrors = false;
@@ -53,25 +54,22 @@ bool Font::PreloadResourceFonts(String fontsDirectoryPath, bool recursive) {
   return false;
 }
 
-bool Font::TallyResourceFonts(String fontsDirectoryPath, vector<String>& fontFilePaths, bool recursive) {
+void Font::TallyResourceFonts(String fontsDirectoryPath, vector<String>& fontFilePaths, bool recursive) {
   wxDir fontsDirectory(fontsDirectoryPath);
-  String fontFileName = "";
-  bool foundFonts = false;
+  String fontFileName = wxEmptyString;
   bool hasNext = fontsDirectory.GetFirst(&fontFileName);
   while (hasNext) {
     String fontFilePath = fontsDirectoryPath + fontFileName;
     if (wxDirExists(fontFilePath)) {
       if (recursive) {
-        foundFonts = foundFonts || TallyResourceFonts(fontFilePath + wxFileName::GetPathSeparator(), fontFilePaths, true);
+        TallyResourceFonts(fontFilePath + wxFileName::GetPathSeparator(), fontFilePaths, true);
       }
     }
     else if (fontFilePath.EndsWith(_(".ttf")) || fontFilePath.EndsWith(_(".otf"))) {
-      foundFonts = true;
       fontFilePaths.push_back(fontFilePath);
     }
     hasNext = fontsDirectory.GetNext(&fontFileName);
   }
-  return foundFonts;
 }
 
 bool Font::update(Context& ctx) {

--- a/src/data/font.hpp
+++ b/src/data/font.hpp
@@ -49,8 +49,10 @@ public:
 
   Font();
 
-  /// Load fonts (.ttf) from the resource/fonts directory
-  static bool PreloadResourceFonts();   
+  /// Load fonts (.ttf or .otf) from the given directory and its subdirectories, returns true if there were errors
+  static bool PreloadResourceFonts(String fontsDirectoryPath, bool recursive);
+  /// Adds font file paths from the given directory into fontFilePaths, returns true if fonts were found
+  static bool TallyResourceFonts(String fontsDirectoryPath, vector<String>& fontFilePaths, bool recursive);
   /// Update the scritables, returns true if there is a change
   bool update(Context& ctx);
   /// Add the given dependency to the dependent_scripts list for the variables this font depends on

--- a/src/data/font.hpp
+++ b/src/data/font.hpp
@@ -46,9 +46,11 @@ public:
   double             shadow_blur;          ///< Blur radius of the shadow
   Color              separator_color;      ///< Color for <sep> text
   int                flags;                ///< FontFlags for this font
-  
+
   Font();
-  
+
+  /// Load fonts (.ttf) from the resource/fonts directory
+  static bool PreloadResourceFonts();   
   /// Update the scritables, returns true if there is a change
   bool update(Context& ctx);
   /// Add the given dependency to the dependent_scripts list for the variables this font depends on
@@ -64,7 +66,7 @@ public:
   
   /// Convert this font to a wxFont
   wxFont toWxFont(double scale) const;
-  
+
 private:
   DECLARE_REFLECTION();
 };

--- a/src/data/font.hpp
+++ b/src/data/font.hpp
@@ -51,8 +51,8 @@ public:
 
   /// Load fonts (.ttf or .otf) from the given directory and its subdirectories, returns true if there were errors
   static bool PreloadResourceFonts(String fontsDirectoryPath, bool recursive);
-  /// Adds font file paths from the given directory into fontFilePaths, returns true if fonts were found
-  static bool TallyResourceFonts(String fontsDirectoryPath, vector<String>& fontFilePaths, bool recursive);
+  /// Adds font file paths from the given directory into fontFilePaths
+  static void TallyResourceFonts(String fontsDirectoryPath, vector<String>& fontFilePaths, bool recursive);
   /// Update the scritables, returns true if there is a change
   bool update(Context& ctx);
   /// Add the given dependency to the dependent_scripts list for the variables this font depends on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <data/locale.hpp>
 #include <data/installer.hpp>
 #include <data/format/formats.hpp>
+#include <data/font.hpp>
 #include <cli/cli_main.hpp>
 #include <cli/text_io_handler.hpp>
 #include <gui/welcome_window.hpp>
@@ -86,6 +87,7 @@ int MSE::OnRun() {
       // Platform friendly appname
       SetAppName(_("magicseteditor"));
     #endif
+    Font::PreloadResourceFonts();
     wxInitAllImageHandlers();
     wxFileSystem::AddHandler(new wxInternetFSHandler); // needed for update checker
     wxSocketBase::Initialize();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ int MSE::OnRun() {
       // Platform friendly appname
       SetAppName(_("magicseteditor"));
     #endif
-    Font::PreloadResourceFonts();
+    Font::PreloadResourceFonts(_("Magic - Fonts"), false);
     wxInitAllImageHandlers();
     wxFileSystem::AddHandler(new wxInternetFSHandler); // needed for update checker
     wxSocketBase::Initialize();


### PR DESCRIPTION
Allows fonts in the `resource/fonts` folder to be properly displayed and exported, no system-wide font installations required! I can't confirm that this works on builds other than `x64-windows-static`, but I can confirm that it will not work on Unix systems, as those require extra dependencies for the wxWidgets private fonts. Regardless, it should not break builds on non-Windows platforms.

No required fonts installed system-wide & no `resource/fonts` folder:

![image](https://github.com/user-attachments/assets/ee631c67-0b77-4c5d-bc40-cb1332f88db7)

No required fonts installed system-wide, but **has** a `resource/fonts` folder:

![image](https://github.com/user-attachments/assets/95e1e061-4c82-48d4-a082-50ae54a26315)

This requires wxWidgets to be installed with the "fonts" feature, which I believe I accomplished with the addition to the CMakeSettings.json file