### PR TITLE
implemented import_image function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On windows, the program can be compiled with Visual Studio (recommended) or with
 
 =======
 ````
-.\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
+.\vcpkg install pkgconf wxwidgets[fonts] boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
 ````
 and/or
 ````

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On windows, the program can be compiled with Visual Studio (recommended) or with
 
 =======
 ````
-.\vcpkg install pkgconf wxwidgets[fonts] boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
+.\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
 ````
 and/or
 ````

--- a/data/en.mse-locale/locale
+++ b/data/en.mse-locale/locale
@@ -803,6 +803,13 @@ error:
 		To resolve this, add:
 		  depends on: %s %s
 
+	# Image import
+	import not found:					File not found: '%s'
+	can't import image without set:		Must first save or load a set file before importing file: '%s'
+	can't create file stream:			Failed to create file stream: '%s'
+	can't write image to set:			Failed to write image to set: '%s'
+	can't import image:					Failed to import image: '%s'
+
 	# Script stuff
 	has no member:						%s has no member '%s'
 	can't convert:						Can't convert from %s to %s

--- a/data/en.mse-locale/locale
+++ b/data/en.mse-locale/locale
@@ -810,6 +810,10 @@ error:
 	can't write image to set:			Failed to write image to set: '%s'
 	can't import image:					Failed to import image: '%s'
 
+	# Card creation
+	no field with name:					Card doesn't have a field named '%s'
+	can't set value:					Can not set card value '%s', it is not of the right type
+
 	# Script stuff
 	has no member:						%s has no member '%s'
 	can't convert:						Can't convert from %s to %s

--- a/doc/function/import_image.txt
+++ b/doc/function/import_image.txt
@@ -10,4 +10,4 @@ Load an image from outside the data folder. Intended for use from the CLI.
 | @input@	[[type:string]]		Full path of the image to load
 
 --Examples--
-> import_image("D:/Art/Ajani.png")
+> new_card([image: import_image("D:/Art/Ajani.png"), card_color: "green"])

--- a/doc/function/import_image.txt
+++ b/doc/function/import_image.txt
@@ -1,0 +1,13 @@
+Function: import_image
+
+--Usage--
+> import_image(image_path)
+
+Load an image from outside the data folder. Intended for use from the CLI.
+
+--Parameters--
+! Parameter	Type			Description
+| @input@	[[type:string]]		Full path of the image to load
+
+--Examples--
+> import_image("D:/Art/Ajani.png")

--- a/doc/function/index.txt
+++ b/doc/function/index.txt
@@ -93,6 +93,7 @@ These functions are built into the program, other [[type:function]]s can be defi
 | [[fun:rotate_image]]		Rotate an image.
 | [[fun:drop_shadow]]		Add a drop shadow to an image.
 | [[fun:symbol_variation]]	Render a variation of a [[type:symbol]].
+| [[fun:import_image]]	Load an image from outside the data folder.
 | [[fun:built_in_image]]	Return an image built into the program.
 	
 ! Cards				<<<

--- a/src/gfx/generated_image.cpp
+++ b/src/gfx/generated_image.cpp
@@ -14,6 +14,7 @@
 #include <data/field/symbol.hpp>
 #include <render/symbol/filter.hpp>
 #include <gui/util.hpp> // load_resource_image
+#include <wx/wfstream.h>
 
 // ----------------------------------------------------------------------------- : GeneratedImage
 
@@ -514,4 +515,51 @@ bool ImageValueToImage::operator == (const GeneratedImage& that) const {
   const ImageValueToImage* that2 = dynamic_cast<const ImageValueToImage*>(&that);
   return that2 && filename == that2->filename
                && age      == that2->age;
+}
+
+// ----------------------------------------------------------------------------- : ExternalImage
+
+Image ExternalImage::generate(const Options& opt) const {
+  wxFileName fname(filepath, wxPATH_UNIX);
+
+  // does the file pointed to by filepath exist?
+  if (!fname.FileExists()) {
+    String filePathString = fname.GetAbsolutePath().ToStdString();
+    throw ScriptError(format_string(_("The file '%s' was not found."),filePathString));
+  }
+
+  String fileExt = fname.GetExt();
+  wxBitmapType bitmapType;
+  if (fileExt == _("png"))
+    bitmapType = wxBITMAP_TYPE_PNG;
+  else if (fileExt == _("jpg"))
+    bitmapType = wxBITMAP_TYPE_JPEG;
+  else
+    bitmapType = wxBITMAP_TYPE_BMP;
+
+  // does the file exist in the package?
+  String fileNameNoExtension = fname.GetName();
+  if (!opt.local_package->existsIn(fileNameNoExtension)) {
+    auto outStream = opt.local_package->openOut(fileNameNoExtension);
+    wxFileInputStream inStream = wxFileInputStream(filepath.ToStdString());
+    if (!inStream.IsOk()) throw ScriptError("Failed to create file stream.");
+    outStream->Write(inStream);
+    if (!outStream->IsOk()) throw ScriptError("Failed to write image to set.");
+    outStream->Close();
+  }
+
+  // save the package with the new image
+  opt.local_package->saveAs(opt.local_package->relativeFilename(), false, false);
+
+  auto imageInputStream = opt.local_package->openIn(fileNameNoExtension);
+  Image img(*imageInputStream.get(), bitmapType);
+
+  if (!img.IsOk()) throw ScriptError("The image could not be created.");
+
+  return img;
+}
+
+bool ExternalImage::operator == (const GeneratedImage& that) const {
+  const ExternalImage* that2 = dynamic_cast<const ExternalImage*>(&that);
+  return that2 && that2->filepath == filepath;
 }

--- a/src/gfx/generated_image.cpp
+++ b/src/gfx/generated_image.cpp
@@ -522,6 +522,10 @@ bool ImageValueToImage::operator == (const GeneratedImage& that) const {
 Image ExternalImage::generate(const Options& opt) const {
   wxFileName fname(filepath, wxPATH_UNIX);
 
+  // has a pre-existing .mse-set file been loaded? 
+  if (opt.local_package->needSaveAs())
+    throw ScriptError(_("Cannot import an image without first saving/loading a set file."));
+
   // does the file pointed to by filepath exist?
   if (!fname.FileExists()) {
     String filePathString = fname.GetAbsolutePath().ToStdString();
@@ -542,19 +546,19 @@ Image ExternalImage::generate(const Options& opt) const {
   if (!opt.local_package->existsIn(fileNameNoExtension)) {
     auto outStream = opt.local_package->openOut(fileNameNoExtension);
     wxFileInputStream inStream = wxFileInputStream(filepath.ToStdString());
-    if (!inStream.IsOk()) throw ScriptError("Failed to create file stream.");
+    if (!inStream.IsOk()) throw ScriptError(_("Failed to create file stream."));
     outStream->Write(inStream);
-    if (!outStream->IsOk()) throw ScriptError("Failed to write image to set.");
+    if (!outStream->IsOk()) throw ScriptError(_("Failed to write image to set."));
     outStream->Close();
   }
 
   // save the package with the new image
-  opt.local_package->saveAs(opt.local_package->relativeFilename(), false, false);
+  opt.local_package->save(false);
 
   auto imageInputStream = opt.local_package->openIn(fileNameNoExtension);
   Image img(*imageInputStream.get(), bitmapType);
 
-  if (!img.IsOk()) throw ScriptError("The image could not be created.");
+  if (!img.IsOk()) throw ScriptError(_("The image could not be created."));
 
   return img;
 }

--- a/src/gfx/generated_image.hpp
+++ b/src/gfx/generated_image.hpp
@@ -399,3 +399,15 @@ private:
   Age age; ///< Age the image was last updated
 };
 
+// ----------------------------------------------------------------------------- : ExternalImage
+
+/// Load an image from the filesystem
+class ExternalImage : public GeneratedImage {
+public:
+    ExternalImage(const String& filepath) : filepath(filepath) {};
+    Image generate(const Options&) const override;
+    bool operator == (const GeneratedImage& that) const override;
+    inline String toString() { return filepath; }
+private:
+    String filepath;
+};

--- a/src/gfx/generated_image.hpp
+++ b/src/gfx/generated_image.hpp
@@ -408,7 +408,7 @@ public:
     Image generate(const Options&) const override;
     bool operator == (const GeneratedImage& that) const override;
     inline String toString() { return filepath; }
-    inline String ExternalImage::toCode() const override { return "<image>"; }
+    inline String toCode() const override { return _("<image>"); }
 private:
     String filepath;
 };

--- a/src/gfx/generated_image.hpp
+++ b/src/gfx/generated_image.hpp
@@ -408,6 +408,7 @@ public:
     Image generate(const Options&) const override;
     bool operator == (const GeneratedImage& that) const override;
     inline String toString() { return filepath; }
+    inline String ExternalImage::toCode() const override { return "<image>"; }
 private:
     String filepath;
 };

--- a/src/script/functions/construction.cpp
+++ b/src/script/functions/construction.cpp
@@ -34,7 +34,7 @@ SCRIPT_FUNCTION(new_card) {
     // find value to update
     IndexMap<FieldP,ValueP>::const_iterator value_it = new_card->data.find(name);
     if (value_it == new_card->data.end()) {
-      throw ScriptError(format_string(_("Card doesn't have a field named '%s'"),name));
+      throw ScriptError(_ERROR_1_("no field with name", name));
     }
     Value* value = value_it->get();
     // set the value
@@ -50,7 +50,7 @@ SCRIPT_FUNCTION(new_card) {
       wxFileName fname( static_cast<ExternalImage*>(v.get())->toString() );
       ivalue->filename = LocalFileName::fromReadString( fname.GetName(), "");
     } else {
-      throw ScriptError(format_string(_("Can not set value '%s', it is not of the right type"),name));
+      throw ScriptError(_ERROR_1_("can't set value", name));
     }
   }
   SCRIPT_RETURN(new_card);

--- a/src/script/functions/construction.cpp
+++ b/src/script/functions/construction.cpp
@@ -14,9 +14,11 @@
 #include <data/field/choice.hpp>
 #include <data/field/package_choice.hpp>
 #include <data/field/color.hpp>
+#include <data/field/image.hpp>
 #include <data/game.hpp>
 #include <data/card.hpp>
 #include <util/error.hpp>
+#include <util/io/package.hpp>
 
 // ----------------------------------------------------------------------------- : new_card
 
@@ -45,6 +47,9 @@ SCRIPT_FUNCTION(new_card) {
       pvalue->package_name = v->toString();
     } else if (ColorValue* cvalue = dynamic_cast<ColorValue*>(value)) {
       cvalue->value = v->toColor();
+    } else if (ImageValue* ivalue = dynamic_cast<ImageValue*>(value)) {
+      wxFileName fname( static_cast<ExternalImage*>(v.get())->toString() );
+      ivalue->filename = LocalFileName::fromReadString( fname.GetName(), "");
     } else {
       throw ScriptError(format_string(_("Can not set value '%s', it is not of the right type"),name));
     }

--- a/src/script/functions/construction.cpp
+++ b/src/script/functions/construction.cpp
@@ -18,7 +18,6 @@
 #include <data/game.hpp>
 #include <data/card.hpp>
 #include <util/error.hpp>
-#include <util/io/package.hpp>
 
 // ----------------------------------------------------------------------------- : new_card
 

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -19,6 +19,7 @@
 #include <data/format/formats.hpp>
 #include <gfx/generated_image.hpp>
 #include <render/symbol/filter.hpp>
+#include <cli/text_io_handler.hpp> // for MSE_CLI
 
 void parse_enum(const String&, ImageCombine& out);
 
@@ -45,8 +46,12 @@ SCRIPT_FUNCTION(to_card_image) {
 }
 
 SCRIPT_FUNCTION(import_image) {
+  SCRIPT_PARAM(Set*, set);
   SCRIPT_PARAM(String, path);
-  return make_intrusive<ExternalImage>(path);
+  auto extImg = make_intrusive<ExternalImage>(path);
+  if (cli.haveConsole()) // makes sure generate() is called, but only once, when using the CLI
+    extImg->generate(GeneratedImage::Options(0, 0, set->stylesheet.get(), set));
+  return extImg;
 }
 
 // ----------------------------------------------------------------------------- : Image functions

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -44,6 +44,11 @@ SCRIPT_FUNCTION(to_card_image) {
   }
 }
 
+SCRIPT_FUNCTION(import_image) {
+  SCRIPT_PARAM(String, path);
+  return make_intrusive<ExternalImage>(path);
+}
+
 // ----------------------------------------------------------------------------- : Image functions
 
 SCRIPT_FUNCTION(width_of) {
@@ -261,4 +266,5 @@ void init_script_image_functions(Context& ctx) {
   ctx.setVariable(_("drop_shadow"),      script_drop_shadow);
   ctx.setVariable(_("symbol_variation"), script_symbol_variation);
   ctx.setVariable(_("built_in_image"),   script_built_in_image);
+  ctx.setVariable(_("import_image"),     script_import_image);
 }

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -47,8 +47,8 @@ SCRIPT_FUNCTION(to_card_image) {
 
 SCRIPT_FUNCTION(import_image) {
   SCRIPT_PARAM(Set*, set);
-  SCRIPT_PARAM(String, path);
-  auto extImg = make_intrusive<ExternalImage>(path);
+  SCRIPT_PARAM(String, input);
+  auto extImg = make_intrusive<ExternalImage>(input);
   if (cli.haveConsole()) // makes sure generate() is called, but only once, when using the CLI
     extImg->generate(GeneratedImage::Options(0, 0, set->stylesheet.get(), set));
   return extImg;

--- a/tools/website/drupal/mse-drupal-modules/highlight.inc
+++ b/tools/website/drupal/mse-drupal-modules/highlight.inc
@@ -88,6 +88,7 @@ $built_in_functions = array(
 	'rotate'		=>'',
 	'drop_shadow'		=>'',
 	'symbol_variation'	=>'',
+	'import_image'	=>'',
 	'built_in_image'	=>'',
 	// cards
 	'new_card'		=>'',


### PR DESCRIPTION
added a way to load images externally from the filesystem during construction, improving on the ideas of #38 and finally closing #36 and #37

![image](https://github.com/user-attachments/assets/61dde6d2-d4a4-4a61-8006-47d349c04cfe)

contrary to the previous image, path strings are directly put into function in place of `path:` prefix:

![image](https://github.com/user-attachments/assets/8d9a67bf-c095-48db-a34f-ae02314beb89)