### PR TITLE
fix compile error

### DIFF
--- a/src/data/font.cpp
+++ b/src/data/font.cpp
@@ -31,7 +31,7 @@ bool Font::PreloadResourceFonts(String fontsDirectoryPath, bool recursive) {
 #if wxUSE_PRIVATE_FONTS
   String pathSeparator(wxFileName::GetPathSeparator());
   String appPath( wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath() );
-  fontsDirectoryPath = appPath + pathSeparator + fontsDirectoryPath + (fontsDirectoryPath.EndsWith(pathSeparator) ? wxEmptyString : pathSeparator);
+  fontsDirectoryPath = appPath + pathSeparator + fontsDirectoryPath + (fontsDirectoryPath.EndsWith(pathSeparator) ? "" : pathSeparator);
 
   if (!wxDirExists(fontsDirectoryPath)) return false;
   


### PR DESCRIPTION
when compiling I am faced with the following error:
```
/home/ebbit/repo/magic/MagicSetEditor2/src/data/font.cpp: In static member function ‘static bool Font::PreloadResourceFonts(String, bool)’:
/home/ebbit/repo/magic/MagicSetEditor2/src/data/font.cpp:34:115: error: operands to ‘?:’ have different types ‘const wxChar*’ {aka ‘const wchar_t*’} and ‘String’ {aka ‘wxString’}
   34 |   fontsDirectoryPath = appPath + pathSeparator + fontsDirectoryPath + (fontsDirectoryPath.EndsWith(pathSeparator) ? wxEmptyString : pathSeparator);
      |                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ebbit/repo/magic/MagicSetEditor2/src/data/font.cpp:34:115: note:   and each type can be converted to the other
```

this pr fixes this error by replacing the "empty" wx string with an empty literal, probably the same, but easier for the compiler to interpret or something.