### PR TITLE
fix position function bugs

### DIFF
--- a/src/script/functions/basic.cpp
+++ b/src/script/functions/basic.cpp
@@ -513,9 +513,9 @@ SCRIPT_FUNCTION(remove_tags) {
 /** 0 based index, -1 if not found */
 int position_in_vector(const ScriptValueP& of, const ScriptValueP& in, const ScriptValueP& order_by, const ScriptValueP& filter) {
   ScriptType of_t = of->type(), in_t = in->type();
-  if (of_t == SCRIPT_STRING || in_t == SCRIPT_STRING) {
+  if (of_t == SCRIPT_STRING && in_t == SCRIPT_STRING) {
     // string finding
-    return (int)of->toString().find(in->toString()); // (int)npos == -1
+    return (int)in->toString().find(of->toString()); // (int)npos == -1
   } else if (order_by || filter) {
     ScriptObject<Set*>*  s = dynamic_cast<ScriptObject<Set*>* >(in.get());
     ScriptObject<CardP>* c = dynamic_cast<ScriptObject<CardP>*>(of.get());


### PR DESCRIPTION
The position function had two bugs:

1. It decided to use string position finding when either argument was a string, when it should have used it when both arguments were strings.
2. the string finding reversed the order of the arguments to be the opposite of what would be semantically correct, as well as the semantics of the finding in a collection/vector logic.

These are both fixed in this PR.

<img width="1920" height="866" alt="magicseteditor_YwgoCJH8Ex" src="https://github.com/user-attachments/assets/2d336cf6-be91-4507-88a7-a517ab1cf939" />
