### PR TITLE
refactor combined_editor and add combined_editor_array

### DIFF
--- a/doc/script/combined_editor.txt
+++ b/doc/script/combined_editor.txt
@@ -1,0 +1,58 @@
+Function: combined_editor
+
+--Usage--
+> forward_editor(field: some_text_value)
+> combined_editor(field1: some_text_value, field2: some_text_value, ..., separator1: some_string, ...)
+> combined_editor_array(fields: array_of_fields, separator: some_string, min_heights: array_of_ints, alignment: vertical_alignment)
+
+Use one text field to edit one or more others.
+
+This function must be used in the @script@ of a [[type:field#text|text field]].
+This field will then contain the combined values of the given fields, separated by the separators in @<sep>@ tags.
+When the field changes the underlying values are updated and vice versa.
+
+Note: @forward_editor@ and @combined_editor@ are the same function. @combined_editor_array@ has additional functionality.
+
+--Parameters--
+! Parameter	Type				Default	Description
+| @field@	[[type:value#text|text value]]	 	Text value to edit
+| @field1@	[[type:value#text|text value]]	 	Another text value to edit
+| @field2@	[[type:value#text|text value]]	 	''etc.''
+| @fields@	[[type:list]] of [[type:value#text|text values]]	 	Exclusive to combined_editor_array, the text values to edit
+| @separator@	[[type:string]]			 	Separator between field 1 and 2, or all fields on combined_editor_array
+| @separator1@	[[type:string]]			 	Multiple separators
+| @separator2@	[[type:string]]			 	Next separator, ''etc.''
+| @prefix@	[[type:string]]		''optional''	Prefix before the combined editor; like a separator between the start and the first field.
+| @suffix@	[[type:string]]		''optional''	Suffix after the combined editor; like a separator between the last field and the end.
+| @hide when empty@	[[type:boolean]]	@false@	Don't include separators if the entire value is empty.
+| @soft before empty@	[[type:boolean]]	@false@	Make separators 'soft' when the value following it is empty.
+			 			 	Soft separators are hidden by default and shown grayed when the field is selected.
+| @min_heights@	[[type:list]] of [[type:int]]		''optional''	Exclusive to combined_editor_array. For each block, applies a min-height [[type:tagged string|tag]] if the matching index is non-zero.
+| @alignment@	vertical [[type:alignment]]	"middle"	Exclusive to combined_editor_array. Relative alignment to apply to text when a block is made larger by the min-height tag.
+
+--Examples--
+>card field:
+>	...
+>	script:
+>>		combined_editor(
+>>			field1: card.first_part
+>>			separator: " - "
+>>			field2: card.second_part
+>>		)
+
+Forwarding just one field should be used in cases when two fields share a value, or when sometimes multiple fields are combined.
+For example the Magic uses:
+>> if set.include_automatic_card_numbers then
+>>   combined_editor(field1:    card.copyright,
+>>                   separator: "/",
+>>                   field2:    card.card_number)
+>> else
+>>   forward_editor(field: card.copyright)
+
+When combining numerous fields, consider using combined_editor_array. Only one kind of separator can be defined, but the fields may be collected and passed as a list instead of indivually.
+>> planeswalker_abilities := [card.level_1_text, card.level_2_text, card.level_3_text, card.level_4_text]
+>> combined_editor_array(
+>>   fields: planeswalker_abilities,
+>>   separator: "<line>\n</line>",
+>>   hide_when_empty: true
+>> )

--- a/doc/type/tagged_string.txt
+++ b/doc/type/tagged_string.txt
@@ -20,6 +20,7 @@ This is written as the character with code 1 in files.
 | @<font:???>@		The text inside the tag is rendered with the given font family.
 | @<align:???>@			The block inside the tag is aligned with the given horizontal [[type:alignment]]
 | @<margin:??:??>@			The block inside the tag has additional left, right (optional), and top (optional) margins of the specified size in pixels.
+| @<min-height:??:??>@			The block inside the tag is rendered at least the given pixel height. The given vertical alignment will apply to the text within the expanded block.
 | @<li>@			The text inside the tag is treated as a list marker, meaning that if the line wraps it will be indented to match the content of the @<li>@ tag.
 | @<line>@		Line breaks inside this tag use the [[prop:style:line height line]], and they show a horizontal line.
 | @<soft-line>@		Line breaks inside this tag use the [[prop:style:soft line height]].

--- a/src/render/text/element.hpp
+++ b/src/render/text/element.hpp
@@ -153,6 +153,8 @@ public:
   size_t start = String::npos, end = String::npos;
   size_t margin_end_char = 0; // end position of characters that are added to the margin (i.e. bullet points)
   double min_height = 0.0;
+  optional<Alignment> internal_valign;
+  bool min_height_closed = false;
 };
 
 /// A list of text elements extracted from a string

--- a/src/render/text/element.hpp
+++ b/src/render/text/element.hpp
@@ -152,6 +152,7 @@ public:
   double margin_top = 0.; //, margin_bottom = 0.; // TODO: more margin options?
   size_t start = String::npos, end = String::npos;
   size_t margin_end_char = 0; // end position of characters that are added to the margin (i.e. bullet points)
+  double min_height = 0.0;
 };
 
 /// A list of text elements extracted from a string

--- a/src/render/text/viewer.cpp
+++ b/src/render/text/viewer.cpp
@@ -13,18 +13,18 @@
 // ----------------------------------------------------------------------------- : Line
 
 struct TextViewer::Line {
-  size_t         start;       ///< Index of the first character in this line
-  size_t         end_or_soft; ///< Index just beyond the last non-soft character
-  vector<double> positions;   ///< x position of each character in this line, gives the number of characters + 1, never empty
-  double         top;         ///< y position of (the top of) this line
-  double         line_height; ///< The height of this line in pixels
-  LineBreak      break_after; ///< Is there a saparator after this line?
+  size_t         start;          ///< Index of the first character in this line
+  size_t         end_or_soft;    ///< Index just beyond the last non-soft character
+  vector<double> positions;      ///< x position of each character in this line, gives the number of characters + 1, never empty
+  double         top;            ///< y position of (the top of) this line
+  double         line_height;    ///< The height of this line in pixels
+  LineBreak      break_after;    ///< Is there a saparator after this line?
   optional<Alignment> alignment; ///< Alignment of this line
-  bool           justifying;  ///< Is the text justified? Only true when *really* justifying.
-  double         margin_left; ///< Left margin
-  double         margin_right;///< Rightmargin
-  double         margin_top;
-  double         margin_bottom;
+  bool           justifying;     ///< Is the text justified? Only true when *really* justifying.
+  double         margin_left;    ///< Left   margin
+  double         margin_right;   ///< Right  margin
+  double         margin_top;     ///< Top    margin
+  double         margin_bottom;  ///< Bottom margin
   
   Line()
     : start(0), end_or_soft(0), top(0), line_height(0)
@@ -711,16 +711,13 @@ bool TextViewer::prepareLinesAtScale(RotatedDC& dc, const vector<CharInfo>& char
       line.start = word_start;
       line.positions.clear();
       if (line.break_after == LineBreak::LINE) line.line_height = 0;
-      if (line.break_after >= LineBreak::HARD) {
-        // end of paragraph
-        assert(elements.paragraphs[i_para].end == i + 1);
-        assert(i_para + 1 < elements.paragraphs.size());
-
+      bool on_last_char = i == chars.size() - 1;
+      if (line.break_after >= LineBreak::HARD || on_last_char) {
         const TextParagraph& para = elements.paragraphs[i_para];
         if (para.min_height > 0.0) {
           startPara = para;
         }
-        if (line.break_after == LineBreak::LINE) {
+        if (line.break_after == LineBreak::LINE || on_last_char) {
           // enforce minimum height for paragraph 
           if (para.min_height_closed) {
             pair<double, double> deltas = computeVerticalDeltas(startPara, lines, current_para_start_line);
@@ -730,6 +727,11 @@ bool TextViewer::prepareLinesAtScale(RotatedDC& dc, const vector<CharInfo>& char
           }
           current_para_start_line = lines.size();
         }
+      }
+      if (line.break_after >= LineBreak::HARD) {
+        // end of paragraph
+        assert(elements.paragraphs[i_para].end == i + 1);
+        assert(i_para + 1 < elements.paragraphs.size());
 
         if (i_para + 1 < elements.paragraphs.size()) ++i_para;
         assert(elements.paragraphs[i_para].start == i + 1);

--- a/src/script/functions/editor.cpp
+++ b/src/script/functions/editor.cpp
@@ -126,8 +126,7 @@ static String handleEmpty(Context& ctx, vector<pair<String, bool>> &value_parts,
         + separators[value_parts.size() - 2]
         + _("</soft></sep>")
         + new_value.substr(after);
-    }
-    else {
+    } else {
       new_value += _("<suffix>") + suffix + _("</suffix>");
     }
   }
@@ -137,7 +136,7 @@ static String handleEmpty(Context& ctx, vector<pair<String, bool>> &value_parts,
   return new_value;
 }
 
-static String recombineParts(Context &ctx, vector<pair<String, bool>> &value_parts, vector<String> &separators, const vector<double>& minHeights = {}) {
+static String recombineParts(Context &ctx, vector<pair<String, bool>> &value_parts, vector<String> &separators, const vector<double>& min_heights = {}, String alignment = "") {
   SCRIPT_PARAM_DEFAULT(bool, hide_when_empty, false);
   SCRIPT_PARAM_DEFAULT(bool, soft_before_empty, false);
   String new_value = value_parts.front().first;
@@ -158,14 +157,9 @@ static String recombineParts(Context &ctx, vector<pair<String, bool>> &value_par
       new_value += _("<sep>") + separators[i - 1] + _("</sep>");
       new_value_empty = false;
     }
-    if (i < minHeights.size() && minHeights[i] > 0.0) {
-      new_value += String::Format(
-        _("<min-height:%g>%s</min-height>"),
-        minHeights[i],
-        value_parts[i].first.c_str()
-      );
-    }
-    else {
+    if (i < min_heights.size() && min_heights[i] > 0.0) {
+      new_value += String::Format(_("<min-height:%g:%s>%s</min-height>"), min_heights[i], alignment, value_parts[i].first);
+    } else {
       new_value += value_parts[i].first;
     }
   }
@@ -279,6 +273,14 @@ static vector<double> readMinHeightsArray(Context& ctx) {
   return result;
 }
 
+static String readAlignment(Context& ctx) {
+  String result = "middle left";
+  SCRIPT_OPTIONAL_PARAM(String, alignment) {
+    result = alignment;
+  }
+  return result;
+}
+
 // This version accepts:
 //   fields: [array of TextField]
 //   separator: string
@@ -289,10 +291,11 @@ SCRIPT_FUNCTION_WITH_DEP(combined_editor_array) {
   vector<TextValue*> values = readFieldArray(ctx);
   vector<String> separators = readRepeatedSeparators(ctx, values);
   vector<double> minHeights = readMinHeightsArray(ctx);
+  String alignment = readAlignment(ctx);
   String value = removePrefixSuffix(ctx);
   vector<pair<String, bool>> value_parts = splitTheValue(value, values.size());
   updateValuesIfInputNewer(ctx, values, value_parts);
-  String new_value = recombineParts(ctx, value_parts, separators, minHeights);
+  String new_value = recombineParts(ctx, value_parts, separators, minHeights, alignment);
   SCRIPT_RETURN(new_value);
 }
 

--- a/src/script/functions/editor.cpp
+++ b/src/script/functions/editor.cpp
@@ -136,10 +136,17 @@ static String handleEmpty(Context& ctx, vector<pair<String, bool>> &value_parts,
   return new_value;
 }
 
+static String min_height_wrap(size_t index, const vector<double>& min_heights, String alignment, vector<pair<String, bool>>& value_parts) {
+  String value = value_parts[index].first;
+  if (index < min_heights.size() && min_heights[index] > 0.0)
+    return String::Format(_("<min-height:%g:%s>%s</min-height>"), min_heights[index], alignment, value);
+  return value;
+}
+
 static String recombineParts(Context &ctx, vector<pair<String, bool>> &value_parts, vector<String> &separators, const vector<double>& min_heights = {}, String alignment = "") {
   SCRIPT_PARAM_DEFAULT(bool, hide_when_empty, false);
   SCRIPT_PARAM_DEFAULT(bool, soft_before_empty, false);
-  String new_value = value_parts.front().first;
+  String new_value = min_height_wrap(0, min_heights, alignment, value_parts);
   bool   new_value_empty = value_parts.front().second;
   size_t size_before_last = 0;
   for (size_t i = 1; i < value_parts.size(); ++i) {
@@ -157,11 +164,7 @@ static String recombineParts(Context &ctx, vector<pair<String, bool>> &value_par
       new_value += _("<sep>") + separators[i - 1] + _("</sep>");
       new_value_empty = false;
     }
-    if (i < min_heights.size() && min_heights[i] > 0.0) {
-      new_value += String::Format(_("<min-height:%g:%s>%s</min-height>"), min_heights[i], alignment, value_parts[i].first);
-    } else {
-      new_value += value_parts[i].first;
-    }
+    new_value += min_height_wrap(i, min_heights, alignment, value_parts);
   }
   if (!new_value_empty || !hide_when_empty)
     new_value = handleEmpty(ctx, value_parts, separators, new_value, size_before_last);

--- a/src/script/to_value.hpp
+++ b/src/script/to_value.hpp
@@ -118,7 +118,9 @@ class ScriptCollection : public ScriptCollectionBase {
 public:
   inline ScriptCollection(const Collection* v) : value(v) {}
   String typeName() const override {
-    return _TYPE_1_("collection of", type_name(*value->begin()));
+      if (!value || value->empty())
+          return _TYPE_1_("collection of", "<empty>");
+      return _TYPE_1_("collection of", type_name(*value->begin()));
   }
   ScriptValueP getIndex(int index) const override {
     if (index >= 0 && index < (int)value->size()) {


### PR DESCRIPTION
This pull request refactors the implementation of the `combined_editor` scripting function and introduces a simplified variant `combined_editor_array` which accepts an array of fields and a single separator as an argument.

## Motivation

The existing `combined_editor` function had grown into a large, monolithic block of code that was difficult to maintain, reason about, or extend.  Although the initial goal was just extending it to support supplying an array of fields as an argument, refactoring it became a necessary intermediate step.

The lack of a way to dynamically pass collections of fields forced template authors to enumerate `field1`, `field2`, etc., which made more complex templates (such as Sagas and Planeswalkers) cumbersome to maintain.

## Changes
**Refactored `combined_editor`**
- Extracted the function’s major logical sections into well-named static helpers:
  - `readFieldArguments`
  - `readSeparatorArguments`
  - `removePrefixSuffix`
  - `splitTheValue`
  - `updateValuesIfInputNewer`
  - `recombineParts`
  - `handleEmpty`

**Refactored `SCRIPT_FUNCTION_DEPENDENCIES(combined_editor)`**
- Split into helper functions:
  - `readDepFieldArguments`
  - `resolveTargetField`
  - `addFieldDependencies`

**Added new Function: `combined_editor_array`**
- Adds support for passing an array of fields and a single separator string, e.g.:
```
combined_editor_array(fields: [card.level_1_text, card.level_2_text, card.level_3_text], separator:"<line>\n</line>")
```
- Allows dynamic generation of combined text from variable-length field sets.
- Supports both direct arrays and variables (e.g., `fields:ar`).

## Benefits

- Improved the maintainability and readability of the `combined_editor` function.  This will make it easier for future changes to be built on demand.
- Enables more flexible and compact scripts that can dynamically compose `combined_editor` fields.
- This work can set the tone for future refactoring of other scripting functions with similar structure.

## Validation

Validation is currently in progress.  I have done initial validation with the major fields on the mainframe template: Name, Power/Toughness, Type/Subtype, flavor text, and card text.  @CajunAvenger is currently doing more broad validation as we speak.

Parity with the following behavior should be verified:
- Prefix/suffix stripping
- Separator insertion 
  - ✔️ power/toughness
  - ✔️ supertype/subtype
- Empty-field handling (hide_when_empty, soft_before_empty) 
  - ✔️ power/toughness
  - ✔️ supertype/subtype

The new combined_editor_array functionality should be tested in real-world template use-cases.

## tl;dr

In short: this PR cleans up one of the larger and more complex functions in the scripting subsystem and adds a requested array-based API for template authors.

The PR will remain a draft until full verification by Cajun of parity and expected functionality has been performed.