### PR TITLE
This fixes incorrect expansion symbol rendering on Linux/wxGTK.

### DIFF
--- a/src/render/symbol/viewer.cpp
+++ b/src/render/symbol/viewer.cpp
@@ -78,12 +78,76 @@ MemoryDCP getTempDC(DC& dc) {
 }
 
 // Combine the temporary DCs used in the drawing with the main dc
-void combineBuffers(DC& dc, DC* borders, DC* interior) {
-  wxSize s = dc.GetSize();
-  if (borders)  dc.Blit(0, 0, s.GetWidth(), s.GetHeight(), borders,  0, 0, wxOR);
-  if (interior) dc.Blit(0, 0, s.GetWidth(), s.GetHeight(), interior, 0, 0, wxAND_INVERT);
+//void combineBuffers(DC& dc, DC* borders, DC* interior) {
+//  wxSize s = dc.GetSize();
+//  if (borders)  dc.Blit(0, 0, s.GetWidth(), s.GetHeight(), borders,  0, 0, wxOR);
+//  if (interior) dc.Blit(0, 0, s.GetWidth(), s.GetHeight(), interior, 0, 0, wxAND_INVERT);/
+//}
+static void bitwiseBlitOr(Image& dst, const Image& src) {
+    int w = dst.GetWidth();
+    int h = dst.GetHeight();
+    if (src.GetWidth() != w || src.GetHeight() != h) return;
+
+    Byte* dd = dst.GetData();
+    const Byte* sd = src.GetData();
+
+    size_t count = (size_t)w * (size_t)h * 3;
+    for (size_t i = 0; i < count; ++i) {
+        dd[i] = dd[i] | sd[i];
+    }
 }
 
+static void bitwiseBlitAndInvert(Image& dst, const Image& src) {
+    int w = dst.GetWidth();
+    int h = dst.GetHeight();
+    if (src.GetWidth() != w || src.GetHeight() != h) return;
+
+    Byte* dd = dst.GetData();
+    const Byte* sd = src.GetData();
+
+    size_t count = (size_t)w * (size_t)h * 3;
+    for (size_t i = 0; i < count; ++i) {
+        dd[i] = dd[i] & (Byte)~sd[i];
+    }
+}
+
+void combineBuffers(DC& dc, DC* borders, DC* interior) {
+    wxSize s = dc.GetSize();
+
+    // Copy base DC into an image
+    Bitmap outBmp(s.GetWidth(), s.GetHeight(), 24);
+    wxMemoryDC outDC;
+    outDC.SelectObject(outBmp);
+    outDC.Blit(0, 0, s.GetWidth(), s.GetHeight(), &dc, 0, 0, wxCOPY);
+    outDC.SelectObject(wxNullBitmap);
+
+    Image out = outBmp.ConvertToImage();
+
+    if (borders) {
+        Bitmap borderBmp(s.GetWidth(), s.GetHeight(), 24);
+        wxMemoryDC borderCopy;
+        borderCopy.SelectObject(borderBmp);
+        borderCopy.Blit(0, 0, s.GetWidth(), s.GetHeight(), borders, 0, 0, wxCOPY);
+        borderCopy.SelectObject(wxNullBitmap);
+
+        Image borderImg = borderBmp.ConvertToImage();
+        bitwiseBlitOr(out, borderImg);
+    }
+
+    if (interior) {
+        Bitmap interiorBmp(s.GetWidth(), s.GetHeight(), 24);
+        wxMemoryDC interiorCopy;
+        interiorCopy.SelectObject(interiorBmp);
+        interiorCopy.Blit(0, 0, s.GetWidth(), s.GetHeight(), interior, 0, 0, wxCOPY);
+        interiorCopy.SelectObject(wxNullBitmap);
+
+        Image interiorImg = interiorBmp.ConvertToImage();
+        bitwiseBlitAndInvert(out, interiorImg);
+    }
+
+    Bitmap finalBmp(out);
+    dc.DrawBitmap(finalBmp, 0, 0, false);
+}
 void SymbolViewer::draw(DC& dc) {
   bool paintedSomething = false;
   bool buffersFilled    = false;

--- a/src/render/symbol/viewer.cpp
+++ b/src/render/symbol/viewer.cpp
@@ -78,76 +78,63 @@ MemoryDCP getTempDC(DC& dc) {
 }
 
 // Combine the temporary DCs used in the drawing with the main dc
-//void combineBuffers(DC& dc, DC* borders, DC* interior) {
-//  wxSize s = dc.GetSize();
-//  if (borders)  dc.Blit(0, 0, s.GetWidth(), s.GetHeight(), borders,  0, 0, wxOR);
-//  if (interior) dc.Blit(0, 0, s.GetWidth(), s.GetHeight(), interior, 0, 0, wxAND_INVERT);/
-//}
-static void bitwiseBlitOr(Image& dst, const Image& src) {
-    int w = dst.GetWidth();
-    int h = dst.GetHeight();
-    if (src.GetWidth() != w || src.GetHeight() != h) return;
-
-    Byte* dd = dst.GetData();
-    const Byte* sd = src.GetData();
-
-    size_t count = (size_t)w * (size_t)h * 3;
-    for (size_t i = 0; i < count; ++i) {
-        dd[i] = dd[i] | sd[i];
-    }
-}
-
-static void bitwiseBlitAndInvert(Image& dst, const Image& src) {
-    int w = dst.GetWidth();
-    int h = dst.GetHeight();
-    if (src.GetWidth() != w || src.GetHeight() != h) return;
-
-    Byte* dd = dst.GetData();
-    const Byte* sd = src.GetData();
-
-    size_t count = (size_t)w * (size_t)h * 3;
-    for (size_t i = 0; i < count; ++i) {
-        dd[i] = dd[i] & (Byte)~sd[i];
-    }
-}
-
 void combineBuffers(DC& dc, DC* borders, DC* interior) {
-    wxSize s = dc.GetSize();
+  if (!borders && !interior) return;
 
-    // Copy base DC into an image
-    Bitmap outBmp(s.GetWidth(), s.GetHeight(), 24);
-    wxMemoryDC outDC;
-    outDC.SelectObject(outBmp);
-    outDC.Blit(0, 0, s.GetWidth(), s.GetHeight(), &dc, 0, 0, wxCOPY);
-    outDC.SelectObject(wxNullBitmap);
+  wxSize size = dc.GetSize();
+  int width = size.GetWidth();
+  int height = size.GetHeight();
 
-    Image out = outBmp.ConvertToImage();
+#ifdef __WXMSW__
+  if (borders)  dc.Blit(0, 0, width, height, borders,  0, 0, wxOR);
+  if (interior) dc.Blit(0, 0, width, height, interior, 0, 0, wxAND_INVERT);
+#else
+  // wxOR and wxAND_INVERT are currently only implemented on Windows, so we have to do them manually
+  size_t count = (size_t)width * (size_t)height * 3;
 
-    if (borders) {
-        Bitmap borderBmp(s.GetWidth(), s.GetHeight(), 24);
-        wxMemoryDC borderCopy;
-        borderCopy.SelectObject(borderBmp);
-        borderCopy.Blit(0, 0, s.GetWidth(), s.GetHeight(), borders, 0, 0, wxCOPY);
-        borderCopy.SelectObject(wxNullBitmap);
+  // Copy base DC into an image
+  Bitmap outBmp(width, height, 24);
+  wxMemoryDC outDC;
+  outDC.SelectObject(outBmp);
+  outDC.Blit(0, 0, width, height, &dc, 0, 0, wxCOPY);
+  outDC.SelectObject(wxNullBitmap);
+  Image outImg = outBmp.ConvertToImage();
+  Byte* outData = outImg.GetData();
 
-        Image borderImg = borderBmp.ConvertToImage();
-        bitwiseBlitOr(out, borderImg);
+  // wxOR border
+  if (borders) {
+    Bitmap borderBmp(width, height, 24);
+    wxMemoryDC borderDC;
+    borderDC.SelectObject(borderBmp);
+    borderDC.Blit(0, 0, width, height, borders, 0, 0, wxCOPY);
+    borderDC.SelectObject(wxNullBitmap);
+    Image borderImg = borderBmp.ConvertToImage();
+    Byte* borderData = borderImg.GetData();
+    for (size_t i = 0; i < count; ++i) {
+      outData[i] = outData[i] | borderData[i];
     }
+  }
 
-    if (interior) {
-        Bitmap interiorBmp(s.GetWidth(), s.GetHeight(), 24);
-        wxMemoryDC interiorCopy;
-        interiorCopy.SelectObject(interiorBmp);
-        interiorCopy.Blit(0, 0, s.GetWidth(), s.GetHeight(), interior, 0, 0, wxCOPY);
-        interiorCopy.SelectObject(wxNullBitmap);
-
-        Image interiorImg = interiorBmp.ConvertToImage();
-        bitwiseBlitAndInvert(out, interiorImg);
+  // wxAND_INVERT interior
+  if (interior) {
+    Bitmap interiorBmp(width, height, 24);
+    wxMemoryDC interiorDC;
+    interiorDC.SelectObject(interiorBmp);
+    interiorDC.Blit(0, 0, width, height, interior, 0, 0, wxCOPY);
+    interiorDC.SelectObject(wxNullBitmap);
+    Image interiorImg = interiorBmp.ConvertToImage();
+    Byte* interiorData = interiorImg.GetData();
+    for (size_t i = 0; i < count; ++i) {
+      outData[i] = outData[i] & (Byte)~interiorData[i];
     }
+  }
 
-    Bitmap finalBmp(out);
-    dc.DrawBitmap(finalBmp, 0, 0, false);
+  Bitmap finalBmp(outImg);
+  dc.DrawBitmap(finalBmp, 0, 0, false);
+#endif
+  
 }
+
 void SymbolViewer::draw(DC& dc) {
   bool paintedSomething = false;
   bool buffersFilled    = false;


### PR DESCRIPTION
The existing code used wxDC logical raster operations to combine
symbol border/interior buffers. That appears to behave differently
under wxGTK/Cairo than under Windows, causing the symbol/background
classification image to come out wrong. The visible result was
inverted-looking expansion symbols (for example, black/white symbol
on a silver background instead of a silver symbol on transparency).

The patch keeps the same intended bitwise composition logic, but
does it explicitly on image pixels instead of relying on backend-
dependent DC logical ops.

Validation:
- Linux build: symbols now render and export correctly
- Windows VM build: symbols still render/export correctly
- Tested against cards from custom sets as well as example cases